### PR TITLE
Added in memory cache service

### DIFF
--- a/backend/Config/RedisConfig.cs
+++ b/backend/Config/RedisConfig.cs
@@ -1,36 +1,65 @@
 using backend.Resources;
 using backend.Utilities;
-
+using Polly;
+using Polly.Retry;
 using StackExchange.Redis;
 
 namespace backend.Config
 {
     public static class RedisConfig
     {
-        public static IServiceCollection AddAppRedis(this IServiceCollection services, IConfiguration config)
+        private static readonly AsyncRetryPolicy _retryPolicy =
+            Policy
+                .Handle<RedisConnectionException>()
+                .Or<TimeoutException>()
+                .WaitAndRetryAsync(
+                    retryCount: 3,
+                    sleepDurationProvider: attempt =>
+                        TimeSpan.FromMilliseconds(200 * Math.Pow(2, attempt)),
+                    onRetry: (ex, delay, attempt, _) =>
+                    {
+                        Logger.Warn(
+                            $"Redis connection attempt {attempt} failed. Retrying in {delay.TotalMilliseconds} ms. Error: {ex.Message}"
+                        );
+                    });
+
+        public static IServiceCollection AddAppRedis(
+            this IServiceCollection services,
+            IConfiguration _)
         {
-            services.AddSingleton<IConnectionMultiplexer>(_ =>
-                ConnectionMultiplexer.Connect(EnvManager.RedisConnection));
+            var health = new RedisHealth();
 
-            services.AddSingleton<RedisResource>();
-
-            using (var scope = services.BuildServiceProvider().CreateScope())
+            try
             {
-                try
+                _retryPolicy.ExecuteAsync(async () =>
                 {
-                    var mux = scope.ServiceProvider.GetRequiredService<IConnectionMultiplexer>();
+                    var mux = await ConnectionMultiplexer.ConnectAsync(
+                        EnvManager.RedisConnection);
+
                     var db = mux.GetDatabase();
 
-                    var latency = db.Ping();
-                    Logger.Info($"Redis connection successful (ping: {latency.TotalMilliseconds} ms).");
-                }
-                catch (Exception ex)
-                {
-                    Logger.Error($"Redis connection error: {ex.Message}");
-                    Environment.Exit(1);
-                }
+                    await db.PingAsync();
+
+                    services.AddSingleton<IConnectionMultiplexer>(mux);
+                    services.AddSingleton(new RedisResource(mux));
+
+                    health.IsAvailable = true;
+
+                    Logger.Info("Redis connection established successfully.");
+                }).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                health.IsAvailable = false;
+                health.Failure = ex;
+
+                Logger.Warn(
+                    ex,
+                    "Redis unavailable after retries — falling back to in-memory cache."
+                );
             }
 
+            services.AddSingleton(health);
             return services;
         }
     }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,5 +1,9 @@
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.RateLimiting;
+
 using backend.Config;
 using backend.Middlewares;
+using backend.Resources;
 using backend.Utilities;
 
 using Serilog;
@@ -13,9 +17,8 @@ Logger.Configure(o =>
 });
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Configuration
-    .AddEnvironmentVariables();
 
+builder.Configuration.AddEnvironmentVariables();
 var port =
     Environment.GetEnvironmentVariable("PORT") ??
     Environment.GetEnvironmentVariable("ASPNETCORE_PORT") ??
@@ -23,20 +26,18 @@ var port =
 
 builder.WebHost.UseUrls($"http://0.0.0.0:{port}");
 builder.Host.UseMinimalSerilog();
-
-builder.Configuration.AddEnvironmentVariables();
-
 builder.Services.AddControllers(options =>
 {
     options.Conventions.Insert(0, new RoutePrefixConvention("api"));
 });
 
 builder.Services.AddApplicationServices();
-
 builder.Services.AddHttpContextAccessor();
+
 builder.Services.AddAppDatabase(builder.Configuration);
 builder.Services.AddAppRedis(builder.Configuration);
 // builder.Services.AddAppMongo(builder.Configuration);
+
 builder.Services.AddJwtAuth(builder.Configuration);
 builder.Services.AddCustomCors();
 builder.Services.AddAppRateLimiter(new RateLimitOptions
@@ -47,13 +48,69 @@ builder.Services.AddAppRateLimiter(new RateLimitOptions
     ReplenishmentPeriod = TimeSpan.FromSeconds(30)
 });
 
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+    options.AddPolicy("local-fallback", context =>
+    {
+        var key =
+            context.User.Identity?.IsAuthenticated == true
+                ? context.User.FindFirst("sub")?.Value ?? "anon"
+                : context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+        return RateLimitPartition.GetTokenBucketLimiter(
+            key,
+            _ => new TokenBucketRateLimiterOptions
+            {
+                TokenLimit = 10,
+                TokensPerPeriod = 10,
+                ReplenishmentPeriod = TimeSpan.FromSeconds(30),
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0
+            });
+    });
+});
+
 var app = builder.Build();
 
 app.UseRouting();
 app.UseCors("AllowFrontend");
+
+app.UseWhen(
+    ctx => !ctx.RequestServices.GetRequiredService<RedisHealth>().IsAvailable,
+    branch =>
+    {
+        branch.UseRateLimiter(new RateLimiterOptions
+        {
+            GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
+            {
+                var key =
+                    httpContext.User.Identity?.IsAuthenticated == true
+                        ? httpContext.User.FindFirst("sub")?.Value ?? "anon"
+                        : httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+                return RateLimitPartition.GetTokenBucketLimiter(
+                    key,
+                    _ => new TokenBucketRateLimiterOptions
+                    {
+                        TokenLimit = 10,
+                        TokensPerPeriod = 10,
+                        ReplenishmentPeriod = TimeSpan.FromSeconds(30),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0
+                    });
+            })
+        });
+    }
+);
+
+app.UseMiddleware<RedisRateLimitMiddleware>();
 app.UseSerilogRequestLogging(opts =>
 {
-    opts.MessageTemplate = "HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms";
+    opts.MessageTemplate =
+        "HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms";
+
     opts.EnrichDiagnosticContext = (ctx, http) =>
     {
         ctx.Set("RequestHost", http.Request.Host.Value!);
@@ -62,30 +119,10 @@ app.UseSerilogRequestLogging(opts =>
     };
 });
 
-app.UseMiddleware<RedisRateLimitMiddleware>();
-
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseStaticFiles();
-
 app.MapControllers();
-
-app.Use(async (context, next) =>
-{
-    await next();
-
-    if (context.Response.StatusCode == StatusCodes.Status404NotFound &&
-        !context.Response.HasStarted)
-    {
-        context.Response.ContentType = "application/json";
-        await context.Response.WriteAsJsonAsync(new
-        {
-            error = "Resource not found",
-            code = 404,
-            path = context.Request.Path
-        });
-    }
-});
 
 app.MapGet("/api", () =>
 {
@@ -105,6 +142,30 @@ app.MapGet("/health", () =>
     });
 });
 
-Logger.Info($"Server is listening on: {port}");
+app.Use(async (context, next) =>
+{
+    await next();
+
+    if (context.Response.StatusCode == StatusCodes.Status404NotFound &&
+        !context.Response.HasStarted)
+    {
+        context.Response.ContentType = "application/json";
+        await context.Response.WriteAsJsonAsync(new
+        {
+            error = "Resource not found",
+            code = 404,
+            path = context.Request.Path
+        });
+    }
+});
+
+var redisHealth = app.Services.GetRequiredService<RedisHealth>();
+Logger.Info(
+    redisHealth.IsAvailable
+        ? "Redis available — using Redis-backed rate limiting."
+        : "Redis unavailable — using ASP.NET local rate limiter fallback."
+);
+
+Logger.Info($"Server is listening on port {port}");
 
 app.Run();

--- a/backend/Resource/AppRedisContext.cs
+++ b/backend/Resource/AppRedisContext.cs
@@ -2,6 +2,12 @@ using StackExchange.Redis;
 
 namespace backend.Resources
 {
+    public sealed class RedisHealth
+    {
+        public bool IsAvailable { get; internal set; }
+        public Exception? Failure { get; internal set; }
+    }
+
     public class RedisResource
     {
         public IDatabase Database { get; }

--- a/backend/Service/InMemoryCacheService.cs
+++ b/backend/Service/InMemoryCacheService.cs
@@ -1,0 +1,168 @@
+using backend.Interfaces;
+using StackExchange.Redis;
+using System.Collections.Concurrent;
+
+namespace backend.Services
+{
+    public sealed class InMemoryCacheService : ICacheService
+    {
+        private sealed record CacheEntry(object Value, DateTime? Expiry);
+
+        private readonly ConcurrentDictionary<string, CacheEntry> _store = new();
+                private bool IsExpired(CacheEntry entry) =>
+            entry.Expiry is not null && entry.Expiry <= DateTime.UtcNow;
+
+        private bool TryGet(string key, out CacheEntry entry)
+        {
+            if (_store.TryGetValue(key, out entry!))
+            {
+                if (IsExpired(entry))
+                {
+                    _store.TryRemove(key, out _);
+                    entry = null!;
+                    return false;
+                }
+                return true;
+            }
+            return false;
+        }
+
+        public Task<bool> SetValueAsync(string key, string value, TimeSpan? expiry = null)
+        {
+            _store[key] = new CacheEntry(
+                value,
+                expiry is null ? null : DateTime.UtcNow.Add(expiry.Value)
+            );
+            return Task.FromResult(true);
+        }
+
+        public Task<string?> GetValueAsync(string key) =>
+            Task.FromResult(
+                TryGet(key, out var e) ? e.Value as string : null
+            );
+
+        public Task<long> IncrementAsync(string key, long value = 1)
+        {
+            var current = TryGet(key, out var e) && long.TryParse(e.Value.ToString(), out var v)
+                ? v
+                : 0;
+
+            var next = current + value;
+            _store[key] = new CacheEntry(next.ToString(), e?.Expiry);
+            return Task.FromResult(next);
+        }
+
+        public Task<long> DecrementAsync(string key, long value = 1) =>
+            IncrementAsync(key, -value);
+
+        private ConcurrentDictionary<string, string> GetHash(string key) =>
+            (TryGet(key, out var e) ? e.Value : null) as ConcurrentDictionary<string, string>
+            ?? new ConcurrentDictionary<string, string>();
+
+        public Task<bool> HashSetAsync(string key, string field, string value)
+        {
+            var hash = GetHash(key);
+            hash[field] = value;
+            _store[key] = new CacheEntry(hash, null);
+            return Task.FromResult(true);
+        }
+
+        public Task<string?> HashGetAsync(string key, string field)
+        {
+            var hash = GetHash(key);
+            return Task.FromResult(hash.TryGetValue(field, out var v) ? v : null);
+        }
+
+        public Task<Dictionary<string, string>> HashGetAllAsync(string key) =>
+            Task.FromResult(new Dictionary<string, string>(GetHash(key)));
+
+        public Task<bool> HashDeleteAsync(string key, string field)
+        {
+            var hash = GetHash(key);
+            return Task.FromResult(hash.TryRemove(field, out _));
+        }
+
+        private ConcurrentDictionary<string, byte> GetSet(string key) =>
+            (TryGet(key, out var e) ? e.Value : null) as ConcurrentDictionary<string, byte>
+            ?? new ConcurrentDictionary<string, byte>();
+
+        public Task<bool> SetAddAsync(string key, string value)
+        {
+            var set = GetSet(key);
+            set.TryAdd(value, 0);
+            _store[key] = new CacheEntry(set, null);
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> SetRemoveAsync(string key, string value)
+        {
+            var set = GetSet(key);
+            return Task.FromResult(set.TryRemove(value, out _));
+        }
+
+        public Task<string[]> SetMembersAsync(string key)
+        {
+            var set = GetSet(key);
+            return Task.FromResult(set.Keys.ToArray());
+        }
+
+        private ConcurrentQueue<string> GetList(string key) =>
+            (TryGet(key, out var e) ? e.Value : null) as ConcurrentQueue<string>
+            ?? new ConcurrentQueue<string>();
+
+        public Task<long> ListLeftPushAsync(string key, string value)
+        {
+            var list = GetList(key);
+            list.Enqueue(value);
+            _store[key] = new CacheEntry(list, null);
+            return Task.FromResult((long)list.Count);
+        }
+
+        public Task<long> ListRightPushAsync(string key, string value) =>
+            ListLeftPushAsync(key, value);
+
+        public Task<string?> ListLeftPopAsync(string key)
+        {
+            var list = GetList(key);
+            return Task.FromResult(list.TryDequeue(out var v) ? v : null);
+        }
+
+        public Task<string?> ListRightPopAsync(string key) =>
+            ListLeftPopAsync(key);
+
+        public Task<bool> DeleteKeyAsync(string key) =>
+            Task.FromResult(_store.TryRemove(key, out _));
+
+        public Task<bool> KeyExistsAsync(string key) =>
+            Task.FromResult(TryGet(key, out _));
+
+        public Task<TimeSpan?> GetTTLAsync(string key) =>
+            Task.FromResult(
+                TryGet(key, out var e) && e.Expiry is not null
+                    ? e.Expiry - DateTime.UtcNow
+                    : null
+            );
+
+        public Task<bool> SetExpiryAsync(string key, TimeSpan expiry)
+        {
+            if (!TryGet(key, out var e)) return Task.FromResult(false);
+            _store[key] = e with { Expiry = DateTime.UtcNow.Add(expiry) };
+            return Task.FromResult(true);
+        }
+
+        public IEnumerable<string> ScanKeys(IServer _, string pattern) =>
+            _store.Keys.Where(k => k.Contains(pattern.Replace("*", "")));
+
+        public Task<bool> AcquireLockAsync(string key, string value, TimeSpan expiry)
+        {
+            return SetValueAsync(key, value, expiry);
+        }
+
+        public Task<bool> ReleaseLockAsync(string key, string value)
+        {
+            var existing = GetValueAsync(key).Result;
+            if (existing != value) return Task.FromResult(false);
+            return DeleteKeyAsync(key);
+        }
+    }
+}


### PR DESCRIPTION
# Summary

- Added a fallback to ASP.NET core default rate limiter if redis fails
- Added retry policies to redis
- Added an inmemory cache service that is used if redis is unavaliable

This should at least address your redis issues @sanjeeveasparan. Ideally, since Redis isn't completely core to the system, it should definitely not cause a full crash

Closes #69 