### PR TITLE
Read the legacy PascalCase Meta envelope key

### DIFF
--- a/frontend/src/app/core/api/models/api-envelope.model.spec.ts
+++ b/frontend/src/app/core/api/models/api-envelope.model.spec.ts
@@ -1,4 +1,9 @@
-import { ApiEnvelope, extractEnvelopeData, requireEnvelopeData } from './api-envelope.model';
+import {
+  ApiEnvelope,
+  extractEnvelopeData,
+  extractEnvelopeMeta,
+  requireEnvelopeData,
+} from './api-envelope.model';
 
 function envelopeOf<T>(overrides: Partial<ApiEnvelope<T>>): ApiEnvelope<T> {
   return {
@@ -41,6 +46,35 @@ describe('extractEnvelopeData', () => {
 
   it('treats a primitive response as the payload itself', () => {
     expect(extractEnvelopeData('raw-string')).toBe('raw-string');
+  });
+});
+
+describe('extractEnvelopeMeta', () => {
+  /** `Meta` is a legacy shim key, so it is not on the interface — see the helper's note. */
+  function withMeta(meta: unknown, legacyMeta?: unknown): ApiEnvelope<null> {
+    return { ...envelopeOf({ meta: meta as never }), Meta: legacyMeta } as ApiEnvelope<null>;
+  }
+
+  it('reads the camelCase meta property', () => {
+    expect(extractEnvelopeMeta(withMeta({ source: 'elasticsearch' }))).toEqual({
+      source: 'elasticsearch',
+    });
+  });
+
+  it('falls back to the legacy PascalCase Meta property', () => {
+    expect(extractEnvelopeMeta(withMeta(null, { totalCount: 3 }))).toEqual({ totalCount: 3 });
+  });
+
+  it('prefers meta over Meta when both are present', () => {
+    expect(extractEnvelopeMeta(withMeta({ totalCount: 3 }, { totalCount: 99 }))).toEqual({
+      totalCount: 3,
+    });
+  });
+
+  it('returns null when the envelope carries no metadata', () => {
+    expect(extractEnvelopeMeta(envelopeOf({ meta: null }))).toBeNull();
+    expect(extractEnvelopeMeta(null)).toBeNull();
+    expect(extractEnvelopeMeta(undefined)).toBeNull();
   });
 });
 

--- a/frontend/src/app/core/api/models/api-envelope.model.ts
+++ b/frontend/src/app/core/api/models/api-envelope.model.ts
@@ -28,6 +28,25 @@ export function extractEnvelopeData<T>(response: ApiEnvelope<T> | T | null | und
   return response as T;
 }
 
+/**
+ * Reads the envelope's side-channel metadata (paging totals, result source), tolerating
+ * the legacy PascalCase key the same way {@link extractEnvelopeData} tolerates `Data`.
+ *
+ * `Meta` is read through a cast rather than declared on {@link ApiEnvelope}: the interface
+ * is generic in its meta type, and adding an optional `Meta?: M` makes the narrowed
+ * response aliases (`EventsApiResponse` and friends) stop accepting a spread of the
+ * wider payload envelope.
+ */
+export function extractEnvelopeMeta<T, M>(
+  response: ApiEnvelope<T, M> | null | undefined,
+): M | null {
+  if (response == null) {
+    return null;
+  }
+
+  return response.meta ?? (response as { Meta?: M }).Meta ?? null;
+}
+
 export function requireEnvelopeData<T>(response: ApiEnvelope<T>, fallbackMessage: string): T {
   const data = response.data ?? response.Data;
   if (data == null) {

--- a/frontend/src/app/features/clubs/pages/clubs-search/clubs-search.component.spec.ts
+++ b/frontend/src/app/features/clubs/pages/clubs-search/clubs-search.component.spec.ts
@@ -260,6 +260,25 @@ describe('ClubsSearchComponent', () => {
       expect(component.sourceLabel).toBe('Fallback results');
     });
 
+    it('reads the source from a legacy PascalCase Meta envelope', () => {
+      clubsService.getClubs.and.returnValue(
+        of({ ...response({ meta: null }), Meta: { source: 'database' } } as ClubsApiResponse),
+      );
+
+      fixture.detectChanges();
+
+      expect(component.sourceLabel).toBe('Fallback results');
+    });
+
+    it('blanks the source when the envelope carries no metadata', () => {
+      clubsService.getClubs.and.returnValue(of(response({ meta: null })));
+
+      fixture.detectChanges();
+
+      expect(component.resultSource).toBe('');
+      expect(component.sourceLabel).toBe('');
+    });
+
     it('reports the envelope message when a successful response carries no data', () => {
       clubsService.getClubs.and.returnValue(
         of(response({ data: null, message: 'Search is temporarily unavailable.' })),

--- a/frontend/src/app/features/clubs/pages/clubs-search/clubs-search.component.ts
+++ b/frontend/src/app/features/clubs/pages/clubs-search/clubs-search.component.ts
@@ -13,7 +13,10 @@ import {
   ClubSortBy,
   ClubType,
 } from '../../models/club.types';
-import { extractEnvelopeData } from '../../../../core/api/models/api-envelope.model';
+import {
+  extractEnvelopeData,
+  extractEnvelopeMeta,
+} from '../../../../core/api/models/api-envelope.model';
 import {
   getApiClientMessage,
   isApiClientClientError,
@@ -232,10 +235,8 @@ export class ClubsSearchComponent implements OnInit, OnDestroy {
           this.clubs = data.items;
           this.totalCount = data.totalCount;
           this.totalPages = data.totalPages;
-          this.resultSource =
-            typeof (response as { meta?: { source?: string } }).meta?.source === 'string'
-              ? ((response as { meta?: { source?: string } }).meta?.source ?? '')
-              : '';
+          const source = extractEnvelopeMeta(response)?.['source'];
+          this.resultSource = typeof source === 'string' ? source : '';
           this.loading = false;
         },
         error: (response) => {

--- a/frontend/src/app/features/events/pages/search/events-search.component.spec.ts
+++ b/frontend/src/app/features/events/pages/search/events-search.component.spec.ts
@@ -252,6 +252,24 @@ describe('EventsSearchComponent', () => {
       expect(component.sourceLabel).toBe('cache');
     });
 
+    it('reads the source from a legacy PascalCase Meta envelope', () => {
+      eventsService.getEvents.and.returnValue(
+        of({ ...response, meta: null, Meta: { source: 'database' } } as EventsApiResponse),
+      );
+
+      createComponent();
+
+      expect(component.sourceLabel).toBe('Fallback results');
+    });
+
+    it('blanks the source when the envelope carries no metadata', () => {
+      eventsService.getEvents.and.returnValue(of({ ...response, meta: null }));
+
+      createComponent();
+
+      expect(component.resultSource).toBe('');
+    });
+
     it('reports the envelope message when a successful response carries no data', () => {
       eventsService.getEvents.and.returnValue(
         of({ ...response, data: null, message: 'Search is temporarily unavailable.' }),

--- a/frontend/src/app/features/events/pages/search/events-search.component.ts
+++ b/frontend/src/app/features/events/pages/search/events-search.component.ts
@@ -15,7 +15,10 @@ import {
   EventSortBy,
   EventStatus,
 } from '../../models/event.types';
-import { extractEnvelopeData } from '../../../../core/api/models/api-envelope.model';
+import {
+  extractEnvelopeData,
+  extractEnvelopeMeta,
+} from '../../../../core/api/models/api-envelope.model';
 import { FeatureFlagsService } from '../../../../core/features/feature-flags.service';
 import { FEATURE_KEYS } from '../../../../core/features/feature-flags.types';
 import {
@@ -494,7 +497,8 @@ export class EventsSearchComponent implements OnInit, OnDestroy {
           this.events = data.items;
           this.totalCount = data.totalCount;
           this.totalPages = data.totalPages;
-          this.resultSource = typeof response.meta?.source === 'string' ? response.meta.source : '';
+          const source = extractEnvelopeMeta(response)?.source;
+          this.resultSource = typeof source === 'string' ? source : '';
           this.loading = false;
         },
         error: (response) => {

--- a/frontend/src/app/features/events/services/event-waitlist.service.spec.ts
+++ b/frontend/src/app/features/events/services/event-waitlist.service.spec.ts
@@ -158,17 +158,37 @@ describe('EventWaitlistService', () => {
       const request = httpMock.expectOne((r) => r.url.includes('/events/42/waitlist'));
       expect(request.request.params.get('page')).toBe('1');
       expect(request.request.params.get('pageSize')).toBe('20');
-      // Note the envelope key stays lowercase `meta` — only the fields inside it are
-      // read in either casing.
       request.flush({
         Data: [{ Id: 1, EventId: 42, UserId: 5, Position: 1, UserName: 'Jamie' }],
-        meta: { TotalCount: 3 },
+        Meta: { TotalCount: 3 },
       });
 
       expect(total).toBe(3);
       expect(entries[0]).toEqual(
         jasmine.objectContaining({ id: 1, eventId: 42, userId: 5, userName: 'Jamie' }),
       );
+    });
+
+    it('reads the total from a lowercase meta with a PascalCase field', () => {
+      let total = 0;
+      service.getEventWaitlist(42).subscribe((page) => (total = page.totalCount));
+
+      httpMock
+        .expectOne((r) => r.url.includes('/events/42/waitlist'))
+        .flush({ data: [{ id: 1 }], meta: { TotalCount: 3 } });
+
+      expect(total).toBe(3);
+    });
+
+    it('prefers the camelCase meta key when both are present', () => {
+      let total = 0;
+      service.getEventWaitlist(42).subscribe((page) => (total = page.totalCount));
+
+      httpMock
+        .expectOne((r) => r.url.includes('/events/42/waitlist'))
+        .flush({ data: [{ id: 1 }], meta: { totalCount: 3 }, Meta: { totalCount: 99 } });
+
+      expect(total).toBe(3);
     });
 
     it('falls back to the entry count when meta carries no total', () => {

--- a/frontend/src/app/features/events/services/event-waitlist.service.ts
+++ b/frontend/src/app/features/events/services/event-waitlist.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpParams } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
 import { environment } from '@environments/environment';
-import { ApiEnvelope } from '../../../core/api/models/api-envelope.model';
+import { ApiEnvelope, extractEnvelopeMeta } from '../../../core/api/models/api-envelope.model';
 import { ApiClient } from '../../../core/api/services/api-client.service';
 import {
   EventWaitlistEntry,
@@ -116,7 +116,7 @@ export class EventWaitlistService {
       .pipe(
         map((response) => {
           const entries = (this.unwrap(response) ?? []).map((entry) => this.normalizeEntry(entry));
-          const meta = response.meta ?? null;
+          const meta = extractEnvelopeMeta(response);
           return {
             entries,
             totalCount: meta?.totalCount ?? meta?.TotalCount ?? entries.length,


### PR DESCRIPTION
## Context

Found while raising frontend coverage in #223. Services unwrap the response envelope's payload as `data ?? Data`, but read `meta` on its own — so a PascalCase `Meta` envelope silently lost its metadata.

## Impact

| Call site | Symptom |
| --- | --- |
| `EventWaitlistService.getEventWaitlist` | `totalCount` fell back to the page length, breaking pagination on the organiser roster |
| `events-search` / `clubs-search` | the "Search index" / "Fallback results" badge blanked out |

## Change

Adds `extractEnvelopeMeta`, symmetric to the existing `extractEnvelopeData`, and routes all three call sites through it. The clubs-search version also drops a duplicated inline cast.

`Meta` is read via a cast inside the helper rather than declared on `ApiEnvelope`. The interface is generic in its meta type, and adding an optional `Meta?: M` makes the narrowed response aliases (`EventsApiResponse` and friends) stop accepting a spread of the wider payload envelope — it breaks five services. There's a comment on the function so nobody "tidies" it onto the interface later.

## Verification

- 829 specs pass; coverage gate green at 93.09% statements / 91.80% branches / 92.84% functions / 93.03% lines
- `npm run typecheck`, `npm run build`, `npm run format:check` all clean
- Reverted the `Meta` fallback and re-ran: **4 tests fail** (waitlist roster, both search components, the helper's own spec), so they pin the behaviour rather than passing incidentally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
