### PR TITLE
Fix 500 on reply/comment delete: run transactions through the execution strategy

### DIFF
--- a/backend.tests.Integration/Infrastructure/TestWebApplicationFactory.cs
+++ b/backend.tests.Integration/Infrastructure/TestWebApplicationFactory.cs
@@ -73,6 +73,13 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
             services.RemoveAll<DbContextOptions>();
             services.RemoveAll<Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsConfiguration<AppDatabaseContext>>();
 
+            // NOTE: this deliberately omits the EnableRetryOnFailure that
+            // DatabaseConfiguration applies in production. Without the retrying execution
+            // strategy, EF permits user-initiated transactions that production rejects, so
+            // code calling BeginTransactionAsync outside CreateExecutionStrategy passes here
+            // and then throws a 500 for real. Aligning the two is the right fix, but 26 call
+            // sites across events, series, registration, waitlist, invitations and payments
+            // still need wrapping first — see the follow-up issue.
             var dbContextOptions = new DbContextOptionsBuilder<AppDatabaseContext>()
                 .UseNpgsql(_testConnectionString)
                 .Options;

--- a/backend/src/main/features/auth/AuthUserRepository.cs
+++ b/backend/src/main/features/auth/AuthUserRepository.cs
@@ -154,83 +154,89 @@ namespace backend.main.features.auth
             if (user == null)
                 return Array.Empty<string>();
 
-            await using var transaction = await _context.Database.BeginTransactionAsync();
-
-            // Deleting the user cascades to their clubs, club versions, events and event
-            // images (all DeleteBehavior.Cascade). EF only removes the rows, so the blob URLs
-            // those rows carry become unrecoverable once the cascade runs. Gather them here,
-            // before the delete, so the caller can clean up the orphaned blobs afterwards.
-            var ownedClubIds = await _context.Clubs
-                .Where(club => club.UserId == id)
-                .Select(club => club.Id)
-                .ToListAsync();
-
-            var orphanedBlobUrls = new List<string>();
-            if (!string.IsNullOrEmpty(user.Avatar))
-                orphanedBlobUrls.Add(user.Avatar);
-
-            if (ownedClubIds.Count > 0)
+            // The context enables retry-on-failure, and that strategy rejects a
+            // user-initiated transaction unless the whole unit runs through it.
+            var strategy = _context.Database.CreateExecutionStrategy();
+            return await strategy.ExecuteAsync(async () =>
             {
-                orphanedBlobUrls.AddRange(await _context.Clubs
-                    .Where(club => ownedClubIds.Contains(club.Id)
-                        && club.ClubImage != null && club.ClubImage != string.Empty)
-                    .Select(club => club.ClubImage!)
-                    .ToListAsync());
+                await using var transaction = await _context.Database.BeginTransactionAsync();
 
-                orphanedBlobUrls.AddRange(await _context.ClubVersions
-                    .Where(version => ownedClubIds.Contains(version.ClubId)
-                        && version.ClubImage != null && version.ClubImage != string.Empty)
-                    .Select(version => version.ClubImage!)
-                    .ToListAsync());
-
-                var ownedEventIds = await _context.Events
-                    .Where(ev => ownedClubIds.Contains(ev.ClubId))
-                    .Select(ev => ev.Id)
+                // Deleting the user cascades to their clubs, club versions, events and event
+                // images (all DeleteBehavior.Cascade). EF only removes the rows, so the blob URLs
+                // those rows carry become unrecoverable once the cascade runs. Gather them here,
+                // before the delete, so the caller can clean up the orphaned blobs afterwards.
+                var ownedClubIds = await _context.Clubs
+                    .Where(club => club.UserId == id)
+                    .Select(club => club.Id)
                     .ToListAsync();
 
-                if (ownedEventIds.Count > 0)
+                var orphanedBlobUrls = new List<string>();
+                if (!string.IsNullOrEmpty(user.Avatar))
+                    orphanedBlobUrls.Add(user.Avatar);
+
+                if (ownedClubIds.Count > 0)
                 {
-                    orphanedBlobUrls.AddRange(await _context.EventImages
-                        .Where(image => ownedEventIds.Contains(image.EventId)
-                            && image.ImageUrl != null && image.ImageUrl != string.Empty)
-                        .Select(image => image.ImageUrl!)
+                    orphanedBlobUrls.AddRange(await _context.Clubs
+                        .Where(club => ownedClubIds.Contains(club.Id)
+                            && club.ClubImage != null && club.ClubImage != string.Empty)
+                        .Select(club => club.ClubImage!)
                         .ToListAsync());
+
+                    orphanedBlobUrls.AddRange(await _context.ClubVersions
+                        .Where(version => ownedClubIds.Contains(version.ClubId)
+                            && version.ClubImage != null && version.ClubImage != string.Empty)
+                        .Select(version => version.ClubImage!)
+                        .ToListAsync());
+
+                    var ownedEventIds = await _context.Events
+                        .Where(ev => ownedClubIds.Contains(ev.ClubId))
+                        .Select(ev => ev.Id)
+                        .ToListAsync();
+
+                    if (ownedEventIds.Count > 0)
+                    {
+                        orphanedBlobUrls.AddRange(await _context.EventImages
+                            .Where(image => ownedEventIds.Contains(image.EventId)
+                                && image.ImageUrl != null && image.ImageUrl != string.Empty)
+                            .Select(image => image.ImageUrl!)
+                            .ToListAsync());
+                    }
                 }
-            }
 
-            // ClubStaff.GrantedByUserId is a Restrict FK, so staff roles this user granted to
-            // others would block the delete. Reassign those grants to the club's owner (falling
-            // back to the affected member) so the role survives and the account can be removed.
-            var grantsByUser = await _context.ClubStaff
-                .Where(staff => staff.GrantedByUserId == id)
-                .ToListAsync();
+                // ClubStaff.GrantedByUserId is a Restrict FK, so staff roles this user granted to
+                // others would block the delete. Reassign those grants to the club's owner (falling
+                // back to the affected member) so the role survives and the account can be removed.
+                var grantsByUser = await _context.ClubStaff
+                    .Where(staff => staff.GrantedByUserId == id)
+                    .ToListAsync();
 
-            if (grantsByUser.Count > 0)
-            {
-                var grantClubIds = grantsByUser.Select(staff => staff.ClubId).Distinct().ToList();
-                var clubOwners = await _context.Clubs
-                    .Where(club => grantClubIds.Contains(club.Id))
-                    .ToDictionaryAsync(club => club.Id, club => club.UserId);
-
-                foreach (var grant in grantsByUser)
+                if (grantsByUser.Count > 0)
                 {
-                    var ownerId = clubOwners.TryGetValue(grant.ClubId, out var owner)
-                        ? owner
-                        : grant.UserId;
-                    grant.GrantedByUserId = ownerId != id ? ownerId : grant.UserId;
+                    var grantClubIds = grantsByUser.Select(staff => staff.ClubId).Distinct().ToList();
+                    var clubOwners = await _context.Clubs
+                        .Where(club => grantClubIds.Contains(club.Id))
+                        .ToDictionaryAsync(club => club.Id, club => club.UserId);
+
+                    foreach (var grant in grantsByUser)
+                    {
+                        var ownerId = clubOwners.TryGetValue(grant.ClubId, out var owner)
+                            ? owner
+                            : grant.UserId;
+                        grant.GrantedByUserId = ownerId != id ? ownerId : grant.UserId;
+                    }
+
+                    await _context.SaveChangesAsync();
                 }
 
+                _context.Users.Remove(user);
                 await _context.SaveChangesAsync();
-            }
 
-            _context.Users.Remove(user);
-            await _context.SaveChangesAsync();
+                await transaction.CommitAsync();
 
-            await transaction.CommitAsync();
-
-            return orphanedBlobUrls
-                .Distinct(StringComparer.Ordinal)
-                .ToList();
+                return orphanedBlobUrls
+                    .Distinct(StringComparer.Ordinal)
+                    .ToList();
+            });
         }
 
         public async Task<User?> GetUserAsync(int id)

--- a/backend/src/main/features/clubs/discussions/replies/ClubDiscussionReplyRepository.cs
+++ b/backend/src/main/features/clubs/discussions/replies/ClubDiscussionReplyRepository.cs
@@ -122,23 +122,34 @@ public sealed class ClubDiscussionReplyRepository : IClubDiscussionReplyReposito
 
     public async Task<ClubDiscussionReply?> SoftDeleteAsync(int id)
     {
-        await using var transaction = await _context.Database.BeginTransactionAsync();
-        var reply = await _context.ClubDiscussionReplies.FindAsync(id);
-        if (reply is null)
-            return null;
-        if (!reply.IsDeleted)
+        // The context is configured with EnableRetryOnFailure, and that execution strategy
+        // refuses a user-initiated transaction unless the whole unit runs through it.
+        var strategy = _context.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync<ClubDiscussionReply?>(async () =>
         {
-            reply.IsDeleted = true;
-            reply.DeletedAt = DateTime.UtcNow;
-            reply.UpdatedAt = reply.DeletedAt.Value;
-            reply.Content = string.Empty;
+            await using var transaction = await _context.Database.BeginTransactionAsync();
+            var reply = await _context.ClubDiscussionReplies.FindAsync(id);
+            if (reply is null)
+                return null;
+
+            if (!reply.IsDeleted)
+            {
+                reply.IsDeleted = true;
+                reply.DeletedAt = DateTime.UtcNow;
+                reply.UpdatedAt = reply.DeletedAt.Value;
+                reply.Content = string.Empty;
+            }
+
+            // Outside the guard on purpose: a retried attempt finds the entity already
+            // mutated in the change tracker, and this delete is idempotent either way.
             await _context.ClubDiscussionReplyReactions
                 .Where(r => r.ReplyId == id)
                 .ExecuteDeleteAsync();
             await _context.SaveChangesAsync();
-        }
-        await transaction.CommitAsync();
-        return reply;
+
+            await transaction.CommitAsync();
+            return reply;
+        });
     }
 
     public async Task<DiscussionReplyReactionSummary> SetReactionAsync(

--- a/backend/src/main/features/clubs/posts/ClubPostService.cs
+++ b/backend/src/main/features/clubs/posts/ClubPostService.cs
@@ -10,6 +10,8 @@ using backend.main.shared.exceptions.http;
 using backend.main.shared.responses;
 using backend.main.shared.utilities.logger;
 
+using Microsoft.EntityFrameworkCore;
+
 namespace backend.main.features.clubs.posts
 {
     public class ClubPostService : IClubPostService
@@ -68,14 +70,13 @@ namespace backend.main.features.clubs.posts
                 IsPinned = isPinned
             };
 
-            await using var transaction = await _db.Database.BeginTransactionAsync();
-
-            post = await _postRepository.CreateAsync(post);
-            _outboxWriter.StageUpsert(post);
-            await _db.SaveChangesAsync();
-            await transaction.CommitAsync();
-
-            return post;
+            return await ExecuteInTransactionAsync(async () =>
+            {
+                post = await _postRepository.CreateAsync(post);
+                _outboxWriter.StageUpsert(post);
+                await _db.SaveChangesAsync();
+                return post;
+            });
         }
 
         public async Task<(ClubPost Post, UserListRecord? Author)> GetByIdAsync(
@@ -178,19 +179,20 @@ namespace backend.main.features.clubs.posts
             if (!await _clubService.CanManageClubPostsAsync(clubId, userId, userRole))
                 throw new ForbiddenException("You are not allowed to update this post.");
 
-            await using var transaction = await _db.Database.BeginTransactionAsync();
-
-            var updated = await _postRepository.UpdateAsync(postId, new ClubPost
+            var updated = await ExecuteInTransactionAsync(async () =>
             {
-                Title = title,
-                Content = content,
-                PostType = postType,
-                IsPinned = isPinned
-            }) ?? throw new ResourceNotFoundException($"Post with ID {postId} was not found.");
+                var post = await _postRepository.UpdateAsync(postId, new ClubPost
+                {
+                    Title = title,
+                    Content = content,
+                    PostType = postType,
+                    IsPinned = isPinned
+                }) ?? throw new ResourceNotFoundException($"Post with ID {postId} was not found.");
 
-            _outboxWriter.StageUpsert(updated);
-            await _db.SaveChangesAsync();
-            await transaction.CommitAsync();
+                _outboxWriter.StageUpsert(post);
+                await _db.SaveChangesAsync();
+                return post;
+            });
 
             await _cache.RemoveAsync(PostCacheKey(postId));
 
@@ -210,12 +212,13 @@ namespace backend.main.features.clubs.posts
             if (!await _clubService.CanManageClubPostsAsync(clubId, userId, userRole))
                 throw new ForbiddenException("You are not allowed to delete this post.");
 
-            await using var transaction = await _db.Database.BeginTransactionAsync();
-
-            await _postRepository.DeleteAsync(postId);
-            _outboxWriter.StageDelete(postId);
-            await _db.SaveChangesAsync();
-            await transaction.CommitAsync();
+            await ExecuteInTransactionAsync(async () =>
+            {
+                await _postRepository.DeleteAsync(postId);
+                _outboxWriter.StageDelete(postId);
+                await _db.SaveChangesAsync();
+                return true;
+            });
 
             await _cache.RemoveAsync(PostCacheKey(postId));
         }
@@ -254,6 +257,33 @@ namespace backend.main.features.clubs.posts
             await PopulateCommentCountsAsync(items);
 
             return (items, totalCount, ResponseSource.Database);
+        }
+
+        /// <summary>
+        /// Runs a unit of work in a transaction through the context's execution strategy.
+        /// </summary>
+        /// <remarks>
+        /// The context enables retry-on-failure, and that strategy rejects a user-initiated
+        /// transaction unless the whole unit runs through it. Mirrors ClubService's helper.
+        /// </remarks>
+        private async Task<T> ExecuteInTransactionAsync<T>(Func<Task<T>> action)
+        {
+            var strategy = _db.Database.CreateExecutionStrategy();
+            return await strategy.ExecuteAsync(async () =>
+            {
+                await using var transaction = await _db.Database.BeginTransactionAsync();
+                try
+                {
+                    var result = await action();
+                    await transaction.CommitAsync();
+                    return result;
+                }
+                catch
+                {
+                    await transaction.RollbackAsync();
+                    throw;
+                }
+            });
         }
 
         private async Task<Dictionary<int, UserListRecord>> FetchAuthorLookupAsync(List<ClubPost> posts)

--- a/backend/src/main/features/clubs/posts/comments/PostCommentRepository.cs
+++ b/backend/src/main/features/clubs/posts/comments/PostCommentRepository.cs
@@ -122,23 +122,34 @@ public sealed class PostCommentRepository : IPostCommentRepository
 
     public async Task<PostComment?> SoftDeleteAsync(int id)
     {
-        await using var transaction = await _context.Database.BeginTransactionAsync();
-        var comment = await _context.PostComments.FindAsync(id);
-        if (comment is null)
-            return null;
-        if (!comment.IsDeleted)
+        // The context is configured with EnableRetryOnFailure, and that execution strategy
+        // refuses a user-initiated transaction unless the whole unit runs through it.
+        var strategy = _context.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync<PostComment?>(async () =>
         {
-            comment.IsDeleted = true;
-            comment.DeletedAt = DateTime.UtcNow;
-            comment.UpdatedAt = comment.DeletedAt.Value;
-            comment.Content = string.Empty;
+            await using var transaction = await _context.Database.BeginTransactionAsync();
+            var comment = await _context.PostComments.FindAsync(id);
+            if (comment is null)
+                return null;
+
+            if (!comment.IsDeleted)
+            {
+                comment.IsDeleted = true;
+                comment.DeletedAt = DateTime.UtcNow;
+                comment.UpdatedAt = comment.DeletedAt.Value;
+                comment.Content = string.Empty;
+            }
+
+            // Outside the guard on purpose: a retried attempt finds the entity already
+            // mutated in the change tracker, and this delete is idempotent either way.
             await _context.PostCommentReactions
                 .Where(reaction => reaction.CommentId == id)
                 .ExecuteDeleteAsync();
             await _context.SaveChangesAsync();
-        }
-        await transaction.CommitAsync();
-        return comment;
+
+            await transaction.CommitAsync();
+            return comment;
+        });
     }
 
     public async Task<PostCommentReactionSummary> SetReactionAsync(

--- a/backend/src/main/features/events/EventsService.cs
+++ b/backend/src/main/features/events/EventsService.cs
@@ -138,25 +138,32 @@ namespace backend.main.features.events
                     UpdatedAt = now
                 };
 
-                await using var transaction = await _db.Database.BeginTransactionAsync();
+                // The context enables retry-on-failure, and that strategy rejects a
+                // user-initiated transaction unless the whole unit runs through it.
+                var strategy = _db.Database.CreateExecutionStrategy();
+                var created = await strategy.ExecuteAsync(async () =>
+                {
+                    await using var transaction = await _db.Database.BeginTransactionAsync();
 
-                var created = await _eventsRepository.CreateAsync(ev);
-                await _db.SaveChangesAsync();
+                    var draft = await _eventsRepository.CreateAsync(ev);
+                    await _db.SaveChangesAsync();
 
-                AddVersionRecord(
-                    created,
-                    EventVersionActions.Create,
-                    actorUserId: userId,
-                    actorRole: NormalizeActorRole(userRole),
-                    rollbackSourceVersionNumber: null,
-                    changedFields: BuildChangedFields(null, BuildSnapshot(created)),
-                    createdAt: now);
+                    AddVersionRecord(
+                        draft,
+                        EventVersionActions.Create,
+                        actorUserId: userId,
+                        actorRole: NormalizeActorRole(userRole),
+                        rollbackSourceVersionNumber: null,
+                        changedFields: BuildChangedFields(null, BuildSnapshot(draft)),
+                        createdAt: now);
 
-                await _imageRepository.AddImagesAsync(created.Id, requestedImageUrls);
-                _outboxWriter.StageSync(created);
+                    await _imageRepository.AddImagesAsync(draft.Id, requestedImageUrls);
+                    _outboxWriter.StageSync(draft);
 
-                await _db.SaveChangesAsync();
-                await transaction.CommitAsync();
+                    await _db.SaveChangesAsync();
+                    await transaction.CommitAsync();
+                    return draft;
+                });
 
                 var withImages = await _eventsRepository.GetByIdAsync(created.Id)
                     ?? throw new InternalServerErrorException("Failed to reload created event");


### PR DESCRIPTION
## Summary

Deleting a discussion reply or a post comment returned a 500:

```
InvalidOperationException: The configured execution strategy
'NpgsqlRetryingExecutionStrategy' does not support user-initiated transactions.
Use the execution strategy returned by 'DbContext.Database.CreateExecutionStrategy()'
to execute all the operations in the transaction as a retriable unit.
```

`DatabaseConfiguration` enables `EnableRetryOnFailure`, and that strategy rejects a transaction opened with `BeginTransactionAsync` unless the whole unit of work runs through `CreateExecutionStrategy`. `SoftDeleteAsync` opened one directly, so **every delete threw before touching the database**.

Wrapped the affected units in the execution strategy, matching the `ExecuteInTransactionAsync` helper `ClubService` already uses:

| Path | Impact |
|---|---|
| `ClubDiscussionReplyRepository.SoftDeleteAsync` | the reported failure |
| `PostCommentRepository.SoftDeleteAsync` | same bug, post comments |
| `ClubPostService` create / update / delete | club posts unusable |
| `EventsService` draft creation | event drafts unusable |
| `AuthUserRepository.DeleteUserAsync` | account deletion unusable |

In the two soft-delete paths the reaction cleanup moved outside the already-deleted guard: a retried attempt finds the entity already mutated in the change tracker and would otherwise skip it, and `ExecuteDelete` is idempotent either way.

## Issues

Pre-existing since #244; surfaced while testing #248. Not caused by the realtime work — #248 only changed where the delete is *published*, not how it is persisted.

## Test

- `dotnet build backend.sln`, `dotnet format backend.sln --verify-no-changes`, `dotnet test backend.tests.Unit` — 1223 pass.
- Reproduced against the running Docker stack before the fix (`HTTP DELETE /api/clubs/11/discussions/2/replies/3 responded 500`), and the exception is gone after rebuilding the backend image.
- Integration tests already cover all of these paths and pass either way — see below for why that is not reassuring.

## Extra notes

**Why CI never caught this.** `TestWebApplicationFactory` rebuilds the `DbContext` with `.UseNpgsql(connectionString)` and no `EnableRetryOnFailure`, so the tests run with EF's permissive default strategy where user-initiated transactions are legal. Every one of these paths is covered by an integration test and every one passes — while the same code 500s in production. The blind spot, not the missing test, is what let this ship.

Aligning the factory with production is the real fix and I attempted it here, but **26 further call sites still open unwrapped transactions** and would all begin failing:

- `EventsService` ×10, `EventSeriesService` ×7, `EventRegistrationService` ×3, `EventWaitlistService` ×3, `EventInvitationService` ×2, `EventWaitlistPromoter` ×1, `PaymentRepository` ×1

Those are the same latent 500 — event registration, waitlists, recurrence series and payments are all affected in production today. Fixing them plus flipping the test factory is a focused follow-up; some (registration uses `Serializable` isolation behind a distributed lock) deserve more care than a mechanical wrap. I left a comment in the factory recording the gap so the next person finds it rather than rediscovering it. Happy to take that follow-up next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
